### PR TITLE
Enable Lodestar with option to disable

### DIFF
--- a/prepare_training_data.py
+++ b/prepare_training_data.py
@@ -7,6 +7,7 @@ import json
 import multiprocessing
 import concurrent.futures
 import functools
+import argparse
 
 from load_blocks import store_block_rewards
 
@@ -18,7 +19,7 @@ REGEX_PATTERNS = {
     "Teku": [r".*[Tt]eku", r"RP-T v[0-9]*\.[0-9]*\.[0-9]*.*"],
     "Nimbus": [r".*[Nn]imbus", r"RP-N v[0-9]*\.[0-9]*\.[0-9]*.*"],
     "Prysm": [r".*[Pp]rysm", "prylabs", r"RP-P v[0-9]*\.[0-9]*\.[0-9]*.*"],
-    "Lodestar": [],
+    "Lodestar": [r".*[Ll]odestar"],
 }
 
 REGEX = {
@@ -27,23 +28,28 @@ REGEX = {
 }
 
 
-def check_graffiti(graffiti: str) -> str:
+def check_graffiti(graffiti: str, disabled_clients=[]) -> str:
     for (client, regexes) in REGEX.items():
+        if client in disabled_clients:
+            continue
+
         for regex in regexes:
             if regex.match(graffiti):
                 return client
     return None
 
 
-def classify_reward_by_graffiti(block_reward) -> str:
-    return check_graffiti(block_reward["meta"]["graffiti"])
+def classify_reward_by_graffiti(block_reward, disabled_clients=[]) -> str:
+    return check_graffiti(
+        block_reward["meta"]["graffiti"], disabled_clients=disabled_clients
+    )
 
 
-def classify_rewards_by_graffiti(rewards):
-    result = {client: [] for client in CLIENTS}
+def classify_rewards_by_graffiti(rewards, disabled_clients=[]):
+    result = {client: [] for client in CLIENTS if client not in disabled_clients}
 
     for reward in rewards:
-        client = classify_reward_by_graffiti(reward)
+        client = classify_reward_by_graffiti(reward, disabled_clients=disabled_clients)
 
         if client is not None:
             result[client].append(reward)
@@ -51,11 +57,13 @@ def classify_rewards_by_graffiti(rewards):
     return result
 
 
-def process_file(raw_data_dir: str, proc_data_dir: str, file_name: str) -> None:
+def process_file(
+    raw_data_dir: str, proc_data_dir: str, disabled_clients: list[str], file_name: str
+) -> None:
     with open(os.path.join(raw_data_dir, file_name), "r") as f:
         rewards = json.load(f)
 
-    res = classify_rewards_by_graffiti(rewards)
+    res = classify_rewards_by_graffiti(rewards, disabled_clients=disabled_clients)
 
     for (client, examples) in res.items():
         for block_rewards in examples:
@@ -65,21 +73,44 @@ def process_file(raw_data_dir: str, proc_data_dir: str, file_name: str) -> None:
     sys.stdout.flush()
 
 
-def main() -> None:
-    raw_data_dir = sys.argv[1]
-    proc_data_dir = sys.argv[2]
+def parse_args():
+    parser = argparse.ArgumentParser("create training data for the KNN classifier")
 
-    try:
-        parallel_workers = sys.argv[3]
-    except IndexError:
-        parallel_workers = multiprocessing.cpu_count()
+    parser.add_argument(
+        "raw_data_dir", help="input containing data to classify using graffiti"
+    )
+    parser.add_argument(
+        "proc_data_dir", help="output for processed data, suitable for KNN training"
+    )
+    parser.add_argument(
+        "--disable",
+        default=[],
+        nargs="+",
+        help="clients to ignore when forming training data",
+    )
+    parser.add_argument(
+        "--num-workers",
+        default=multiprocessing.cpu_count(),
+        help="number of parallel processes to utilize",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    raw_data_dir = args.raw_data_dir
+    proc_data_dir = args.proc_data_dir
+    parallel_workers = args.num_workers
+    disabled_clients = args.disable
 
     input_files = os.listdir(raw_data_dir)
 
     with concurrent.futures.ProcessPoolExecutor(
         max_workers=parallel_workers
     ) as executor:
-        partial = functools.partial(process_file, raw_data_dir, proc_data_dir)
+        partial = functools.partial(
+            process_file, raw_data_dir, proc_data_dir, disabled_clients
+        )
         executor.map(partial, input_files)
 
 

--- a/tests/test_classifier_persister.py
+++ b/tests/test_classifier_persister.py
@@ -2,7 +2,8 @@ import pickle
 import json
 import os
 from typing import Any, Dict, List
-from knn_classifier import ENABLED_CLIENTS, Classifier, persist_classifier
+from knn_classifier import Classifier, persist_classifier
+from prepare_training_data import CLIENTS
 
 
 def create_test_classifier() -> Classifier:
@@ -29,6 +30,6 @@ def test_classifier_persister() -> None:
             clf_loaded = pickle.load(fid)
             test_blocks = load_test_blocks()
             for b in test_blocks:
-                assert clf_loaded.classify(b)[0] in ENABLED_CLIENTS
+                assert clf_loaded.classify(b)[0] in CLIENTS
     finally:
         os.remove(f"{name}.pkl")

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -11,9 +11,12 @@ def test_preprocessor() -> None:
     raw_data_dir = "tests/data"
     input_files = os.listdir(raw_data_dir)
     proc_data_dir = f"/tmp/run-{str(int(time.time()))}"
+    disabled_clients = ["Lodestar"]
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=2) as executor:
-        partial = functools.partial(process_file, raw_data_dir, proc_data_dir)
+        partial = functools.partial(
+            process_file, raw_data_dir, proc_data_dir, disabled_clients
+        )
         executor.map(partial, input_files)
 
     generated_files = []


### PR DESCRIPTION
* Add graffiti regex for Lodestar
* Add a proper arg parser to `prepare_training_data`. This changes the syntax for the parallel workers flag from a positional arg to an optional `--num-workers` flag
* Add a `--disable` flag to `prepare_training_data` that causes training data not to be produced for the listed clients
* Add a `--disable` flag to `knn_classifier` that ignores training data for the listed clients

I don't think we urgently need a `--disable` flag on `build_db` because it can be used with training data that simply omits certain clients, and that will be handled gracefully.