### PR TITLE
Add new features and interactive notebook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ venv
 __pycache__/
 .DS_Store
 *.pkl
+*.zst
+.ipynb_checkpoints

--- a/feature_selection.py
+++ b/feature_selection.py
@@ -30,6 +30,15 @@ def feat_num_redundant(block_reward):
     return redundant_attestations
 
 
+def feat_percent_redundant_boost(block_reward):
+    "Add +0.2 to the redundant percentage to create some separation from the 0.0 line"
+    percent_redundant = ALL_FEATURES["percent_redundant"](block_reward)
+    if percent_redundant == 0.0:
+        return 0.0
+    else:
+        return min(1.0, percent_redundant + 0.2)
+
+
 def feat_num_pairwise_ordered(block_reward):
     per_attestation_rewards = block_reward["attestation_rewards"][
         "per_attestation_rewards"
@@ -104,6 +113,7 @@ ALL_FEATURES = {
     "num_attestations": feat_num_attestations,
     "num_redundant": feat_num_redundant,
     "percent_redundant": scale_by_num_attestations(feat_num_redundant),
+    "percent_redundant_boost": feat_percent_redundant_boost,
     "num_pairwise_ordered": feat_num_pairwise_ordered,
     "percent_pairwise_ordered": scale_by_num_attestations(feat_num_pairwise_ordered),
     "reward": feat_total_reward,

--- a/interactive.ipynb
+++ b/interactive.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from knn_classifier import Classifier"
+    "from knn_classifier import Classifier, DEFAULT_FEATURES"
    ]
   },
   {
@@ -17,10 +17,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datadir = \"data/mainnet/training/slots_3481601_to_3702784_no_nimbus_2x\"\n",
+    "datadir = \"data/mainnet/training/slots_3481601_to_3702784_bal2x\"\n",
     "disabled_clients = []\n",
+    "features = ['percent_redundant', 'percent_pairwise_ordered', 'norm_reward']\n",
     "\n",
-    "classifier = Classifier(datadir, disabled_clients=disabled_clients)"
+    "classifier = Classifier(datadir, disabled_clients=disabled_clients, features=features)"
    ]
   },
   {

--- a/interactive.ipynb
+++ b/interactive.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9db84fa1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from knn_classifier import Classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73202c43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datadir = \"data/mainnet/training/slots_3481601_to_3702784_no_nimbus_2x\"\n",
+    "disabled_clients = []\n",
+    "\n",
+    "classifier = Classifier(datadir, disabled_clients=disabled_clients)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "123d0e68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "\n",
+    "classifier.plot_feature_matrix(None)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/knn_classifier.py
+++ b/knn_classifier.py
@@ -20,14 +20,21 @@ WEIGHTS = "distance"
 MIN_GUESS_THRESHOLD = 0.20
 CONFIDENCE_THRESHOLD = 0.95
 
-DEFAULT_FEATURES = ["percent_redundant_boost", "percent_pairwise_ordered", "norm_reward"]
+DEFAULT_FEATURES = [
+    "percent_redundant_boost",
+    "percent_pairwise_ordered",
+    "spearman_correlation",
+    "mean_density",
+]
 
 VIABLE_FEATURES = [
+    "percent_redundant_boost",
     "percent_pairwise_ordered",
-    "percent_redundant",
+    "difflib_sorted_distance",
+    "spearman_correlation",
     "norm_reward",
-    "norm_reward_per_slot",
-    "median_density",
+    "mean_density",
+    "percent_single_bit",
 ]
 
 

--- a/knn_classifier.py
+++ b/knn_classifier.py
@@ -20,7 +20,7 @@ WEIGHTS = "distance"
 MIN_GUESS_THRESHOLD = 0.20
 CONFIDENCE_THRESHOLD = 0.95
 
-DEFAULT_FEATURES = ["percent_redundant", "percent_pairwise_ordered", "norm_reward"]
+DEFAULT_FEATURES = ["percent_redundant_boost", "percent_pairwise_ordered", "norm_reward"]
 
 VIABLE_FEATURES = [
     "percent_pairwise_ordered",
@@ -145,7 +145,10 @@ class Classifier:
         ax.set_ylabel(self.features[1])
         ax.set_zlabel(self.features[2])
 
-        fig.savefig(output_path)
+        if output_path is None:
+            fig.show()
+        else:
+            fig.savefig(output_path)
 
 
 def compute_guess_list(probability_map, enabled_clients) -> list:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ falcon==3.0.1
 sseclient-py==1.7.2
 gunicorn==20.1.0
 matplotlib==3.5.1
+scipy==1.8.0


### PR DESCRIPTION
* Add interactive Jupyter notebook for exploring plots of the feature space more easily
* Add several new features with better performance than the previous set:
    - `percent_redundant_boost`: the same as `percent_redundant` but adds +0.2 to any non-zero measurement to create separation between the blocks with no-redundancy and the blocks with redundancy
    - `mean_density`: same as `median_density` but using the mean to allow the measurement to be influenced by outliers
    - `difflib_sorted_distance`: based on the same idea as `percent_pairwise_ordered` but taking into account more of the ordering characteristics. Python's `difflib` is part of the standard library and provides a metric for sequence similarity in the range 0-1.
    - `spearman_correlation`: similar to `difflib_sorted_distance`, calculates [Spearman's rank correlation coefficient](https://en.wikipedia.org/wiki/Spearman's_rank_correlation_coefficient) for the list of per attestation rewards relative to its sorted version.
* Updates the default feature set to `[percent_redundant_boost, percent_pairwise_ordered, spearman_correlation, mean_density]`. This feature set performed the best during cross validation on slots 3481601 to 3702784, with the training data balanced using `balance.py` to a max-imbalance of 2x. This improved CV performance also carried over into improved performance when classifying the most recent portion of the chain, with a minimum sensitivity of 0.80 (Prysm) and a min precision of 0.62 (Prysm). See run 13 in the spreadsheet here: https://docs.google.com/spreadsheets/d/1ly8dT8ngWeU0KQFm3Ec_SKcyxs_jzEGopQYRCGt8NXc.