### PR TITLE
Features based on AttestationData ordering

### DIFF
--- a/knn_classifier.py
+++ b/knn_classifier.py
@@ -22,22 +22,29 @@ CONFIDENCE_THRESHOLD = 0.95
 
 DEFAULT_FEATURES = [
     "percent_redundant_boost",
-    "percent_pairwise_ordered",
-    "spearman_correlation",
-    "mean_density",
+    "difflib_rewards",
+    "difflib_slot",
+    "difflib_slot_rev",
 ]
-
 
 DEFAULT_GRAFFITI_ONLY = ["Lodestar"]
 
 VIABLE_FEATURES = [
     "percent_redundant_boost",
     "percent_pairwise_ordered",
-    "difflib_sorted_distance",
+    "difflib_rewards",
+    "difflib_slot_index",
+    "difflib_index_slot",
+    "difflib_slot_index_rev",
+    "difflib_index_slot_rev",
+    "difflib_slot",
+    "difflib_slot_rev",
     "spearman_correlation",
     "norm_reward",
     "mean_density",
     "percent_single_bit",
+    "difflib_slot_reward",
+    "difflib_slot_reward_rev",
 ]
 
 
@@ -99,7 +106,10 @@ class Classifier:
                 with open(os.path.join(client_dir, reward_file), "r") as f:
                     block_reward = json.load(f)
 
-                feature_matrix.append(into_feature_row(block_reward, features))
+                feature_row = into_feature_row(block_reward, features)
+                feature_matrix.append(feature_row)
+
+                # print(f"{client}: {feature_row}")
 
                 if client in grouped_clients:
                     training_labels.append(other_index)
@@ -279,6 +289,9 @@ def main():
     ]
 
     if enable_cv:
+        best_score = 0.0
+        best_features = None
+
         print("performing cross validation")
         if num_features is None:
             feature_vecs = [DEFAULT_FEATURES]
@@ -300,6 +313,15 @@ def main():
                 )
                 print(f"enabled clients: {classifier.enabled_clients}")
                 print(f"classifier scores: {classifier.scores['test_score']}")
+
+                min_score = min(classifier.scores["test_score"])
+
+                if min_score > best_score:
+                    best_features = feature_vec
+                    best_score = min_score
+
+        print(f"best features found: {best_features}")
+        print(f"score: {best_score}")
         return
 
     assert classify_dir is not None, "classify dir required"

--- a/load_all.fish
+++ b/load_all.fish
@@ -2,7 +2,7 @@
 
 set slots_per_period 221184
 set num_periods 1
-set offset 3039232
+set offset 3760128
 
 for i in (seq 0 (math "$num_periods -  1"))
     set start_slot (math "$offset + $i * $slots_per_period + 1")

--- a/load_blocks.py
+++ b/load_blocks.py
@@ -7,6 +7,7 @@ import requests
 
 BLOCK_STORAGE = "blocks"
 BEACON_NODE = "http://localhost:5052"
+DEFAULT_BATCH_SIZE = os.environ.get("DEFAULT_BATCH_SIZE") or 2048
 
 
 def load_or_download_blocks(
@@ -67,9 +68,12 @@ def store_block_rewards(block_rewards, client, proc_data_dir):
 
 
 def download_block_reward_batches(
-    start_slot, end_slot, output_dir, beacon_node=BEACON_NODE, batch_size=2048
+    start_slot,
+    end_slot,
+    output_dir,
+    beacon_node=BEACON_NODE,
+    batch_size=DEFAULT_BATCH_SIZE,
 ):
-    # assert start_slot % 2048 == 1, "batch start should be 1 mod 2048 for efficiency"
     for batch_start in range(start_slot, end_slot, batch_size):
         batch_end = min(batch_start + batch_size - 1, end_slot)
 
@@ -89,7 +93,7 @@ def download_block_reward_batches(
 
 
 def download_block_rewards(start_slot, end_slot, beacon_node=BEACON_NODE):
-    url = f"{beacon_node}/lighthouse/analysis/block_rewards?start_slot={start_slot}&end_slot={end_slot}"  # noqa: E501
+    url = f"{beacon_node}/lighthouse/analysis/block_rewards?start_slot={start_slot}&end_slot={end_slot}&include_attestations=true"  # noqa: E501
     res = requests.get(url)
     res.raise_for_status()
     return res.json()

--- a/prepare_training_data.py
+++ b/prepare_training_data.py
@@ -15,10 +15,10 @@ from load_blocks import store_block_rewards
 CLIENTS = ["Lighthouse", "Lodestar", "Nimbus", "Other", "Prysm", "Teku"]
 
 REGEX_PATTERNS = {
-    "Lighthouse": [r".*[Ll]ighthouse", r"RP-L v[0-9]*\.[0-9]*\.[0-9]*.*"],
-    "Teku": [r".*[Tt]eku", r"RP-T v[0-9]*\.[0-9]*\.[0-9]*.*"],
-    "Nimbus": [r".*[Nn]imbus", r"RP-N v[0-9]*\.[0-9]*\.[0-9]*.*"],
-    "Prysm": [r".*[Pp]rysm", "prylabs", r"RP-P v[0-9]*\.[0-9]*\.[0-9]*.*"],
+    "Lighthouse": [r".*[Ll]ighthouse", r"RP-[A-Z]?L v[0-9]*\.[0-9]*\.[0-9]*.*"],
+    "Teku": [r".*[Tt]eku", r"RP-[A-Z]?T v[0-9]*\.[0-9]*\.[0-9]*.*"],
+    "Nimbus": [r".*[Nn]imbus", r"RP-[A-Z]?N v[0-9]*\.[0-9]*\.[0-9]*.*"],
+    "Prysm": [r".*[Pp]rysm", "prylabs", r"RP-[A-Z]?P v[0-9]*\.[0-9]*\.[0-9]*.*"],
     "Lodestar": [r".*[Ll]odestar"],
 }
 
@@ -91,6 +91,7 @@ def parse_args():
     parser.add_argument(
         "--num-workers",
         default=multiprocessing.cpu_count(),
+        type=int,
         help="number of parallel processes to utilize",
     )
     return parser.parse_args()


### PR DESCRIPTION
This PR improves the cross validation score to around 0.95 by computing new features based on the ordering of `AttestationData` within blocks. Previously we relied entirely on the ordering of attestation _rewards_, but several clients seem to order based on attestation `slot` instead.

From now on, to use blockprint with these new `difflib` features will require a version of Lighthouse containing this commit: https://github.com/sigp/lighthouse/commit/53b2b500dbb9f00b5d6dd4da065e52d7ba186f9a (at time of writing, no release includes this commit but it will be in v2.3.2/v2.4.0).

Finally, the graffiti regex were also updated to support recent versions of RocketPool which include an extra letter like `RP-NL` for Nethermind-Lighthouse.