### PR TITLE
Add `validators/blocks/latest` API endpoint

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -10,6 +10,7 @@ from build_db import (
     get_sync_gaps,
     update_block_db,
     get_validator_blocks,
+    get_all_validators_latest_blocks,
     get_blocks,
     count_true_positives,
     count_true_negatives,
@@ -128,6 +129,15 @@ class MultipleValidatorsBlocks:
         resp.text = json.dumps(all_blocks, ensure_ascii=False)
 
 
+class AllValidatorsLatestBlocks:
+    def __init__(self, block_db):
+        self.block_db = block_db
+
+    def on_get(self, req, resp):
+        result = get_all_validators_latest_blocks(self.block_db)
+        resp.text = json.dumps(result, ensure_ascii=False)
+
+
 class Blocks:
     def __init__(self, block_db):
         self.block_db = block_db
@@ -178,6 +188,7 @@ app.add_route(
 )
 app.add_route("/validator/blocks", MultipleValidatorsBlocks(block_db))
 app.add_route("/validator/blocks/{since_slot:int}", MultipleValidatorsBlocks(block_db))
+app.add_route("/validator/blocks/latest", AllValidatorsLatestBlocks(block_db))
 app.add_route("/blocks/{start_slot:int}", Blocks(block_db))
 app.add_route("/blocks/{start_slot:int}/{end_slot:int}", Blocks(block_db))
 app.add_route("/sync/status", SyncStatus(block_db))

--- a/build_db.py
+++ b/build_db.py
@@ -250,6 +250,28 @@ def get_validator_blocks(block_db, validator_index, since_slot=None):
     return [row_to_json(row) for row in rows]
 
 
+def get_all_validators_latest_blocks(block_db):
+    rows = block_db.execute(
+        """SELECT b1.proposer_index, b1.slot, b1.best_guess_single
+           FROM blocks b1
+           JOIN (SELECT MAX(slot) AS slot, proposer_index FROM blocks GROUP BY proposer_index)
+           AS b2 ON b1.slot = b2.slot AND b1.proposer_index = b2.proposer_index;"""
+    )
+
+    def row_to_json(row):
+        proposer_index = int(row[0])
+        slot = row[1]
+        best_guess_single = row[2]
+
+        return {
+            "proposer_index": proposer_index,
+            "slot": slot,
+            "best_guess_single": best_guess_single,
+        }
+
+    return [row_to_json(row) for row in rows]
+
+
 def get_blocks(block_db, start_slot, end_slot=None):
     end_slot = end_slot or (1 << 62)
 

--- a/docs/validator_api.md
+++ b/docs/validator_api.md
@@ -103,6 +103,38 @@ curl -u user:pass -X POST --data "[1023, 1024]" "https://api.blockprint.sigp.io/
 }
 ```
 
+## `/validator/blocks/latest`
+
+Fetch the slot of the most recent block proposed by each validator along with the corresponding `best_guess_single`.
+This is useful when you need an overview of the whole validator set at the current moment and are not interested in previous blocks.
+
+## Example
+
+```bash
+curl -u user:pass "https://api.blockprint.sigp.io/validator/blocks/latest"
+```
+
+```json
+[
+  {
+    "proposer_index": 0,
+    "slot": 4430606,
+    "best_guess_single": "[REDACTED]"
+  },
+  {
+    "proposer_index": 1,
+    "slot": 4457868,
+    "best_guess_single": "[REDACTED]"
+  },
+  {
+    "proposer_index": 2,
+    "slot": 4222303,
+    "best_guess_single": "[REDACTED]"
+  },
+  ...
+]
+```
+
 ## `/blocks/{start_slot}/{end_slot}`
 
 Fetch detailed information on all blocks in a given range, including proposer


### PR DESCRIPTION
This PR adds an API endpoint at `validators/blocks/latest`.
This endpoint returns a list of each validator, their most recently proposed block and the `best_guess_single` for that block.

Usage examples can be seen in `docs/validator_api.md`