### PR TITLE
Dump client configs from current infra

### DIFF
--- a/infra/cl-configs/grandine-all.service
+++ b/infra/cl-configs/grandine-all.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Grandine (subscribe all)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStartPre=-/usr/bin/docker stop grandine-all
+ExecStartPre=-/usr/bin/docker rm grandine-all
+# ExecStartPre=/usr/bin/docker pull sifrai/grandine:unstable
+ExecStart=docker run --rm --name grandine-all --network host --mount "type=bind,src=/storage/grandine/all,dst=/mnt/grandine" \
+	sifrai/grandine:unstable \
+	--data-dir /mnt/grandine \
+	--libp2p-port 9005 \
+	--discovery-port 9005 \
+	--http-port 7005 \
+	--eth1-rpc-urls "http://localhost:8552/canonical" \
+	--jwt-secret "/mnt/grandine/jwt.hex" \
+        --jwt-id "bpw2" \
+	--suggested-fee-recipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--checkpoint-sync-url "http://localhost:9052" \
+        --subscribe-all-subnets
+        # --force-checkpoint-sync \

--- a/infra/cl-configs/lighthouse-all-dockerised.service
+++ b/infra/cl-configs/lighthouse-all-dockerised.service
@@ -1,0 +1,33 @@
+[Install]
+WantedBy=multi-user.target
+[Unit]
+Description=Lighthouse BN
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStartPre=-/usr/bin/docker stop lighthouse-all
+ExecStartPre=-/usr/bin/docker rm lighthouse-all
+ExecStart=docker run --rm --name lighthouse-all --network host --mount "type=bind,src=/storage/lighthouse/all,dst=/mnt/lighthouse" \
+	sigmaprime/lighthouse:michaelsproul-fetch-blobs-earlier-5f563ef \
+	lighthouse bn \
+	--datadir /mnt/lighthouse \
+	--port 9005 \
+	--http-port 7005 \
+	--http \
+	--disable-quic \
+	--metrics \
+	--checkpoint-sync-url "https://mainnet.checkpoint.sigp.io" \
+	--execution-endpoint "http://localhost:8552/canonical" \
+	--execution-jwt "/mnt/lighthouse/jwt.hex" \
+	--suggested-fee-recipient=0xffffffffffffffffffffffffffffffffffffffff \
+	--subscribe-all-subnets \
+	--import-all-attestations \
+	--always-prepare-payload \
+	--prepare-payload-lookahead 8000

--- a/infra/cl-configs/lighthouse-all.service
+++ b/infra/cl-configs/lighthouse-all.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Lighthouse BN
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=sigp
+Group=sigp
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/sigp
+ExecStart=docker run --network host --mount "type=bind,src=/storage/lighthouse/all,dst=/mnt/lighthouse" \
+	sigp/lighthouse:latest-unstable lighthouse bn \
+	--datadir /mnt/lighthouse \
+	--port 9000 \
+	--http-port 7001 \
+	--http \
+	--disable-quic \
+	--checkpoint-sync-url "https://mainnet.checkpoint.sigp.io" \
+	--execution-endpoint "https://api.blockprint.sigp.io/eleel" \
+	--execution-jwt "/mnt/lighthouse/jwt.hex" \
+	--execution-jwt-id "bpw1" \
+	--suggested-fee-recipient=0xffffffffffffffffffffffffffffffffffffffff \
+	--subscribe-all-subnets \
+	--import-all-attestations \
+	--always-prepare-payload \
+	--prepare-payload-lookahead 8000
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/lodestar-all.service
+++ b/infra/cl-configs/lodestar-all.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Lodestar (subscribe all)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStart=docker run --network host --mount "type=bind,src=/storage/lodestar/all,dst=/mnt/lodestar" \
+	chainsafe/lodestar:v1.13.0-rc.0 \
+	beacon \
+	--dataDir "/mnt/lodestar" \
+	--execution.urls "https://api.blockprint.sigp.io/eleel" \
+	--jwt-secret "/mnt/lodestar/jwt.hex" \
+	--jwtId "bpw3" \
+	--checkpointSyncUrl "https://mainnet.checkpoint.sigp.io" \
+	--suggestedFeeRecipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--port 9000 \
+	--rest.port 7000 \
+	--subscribe-all-subnets
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/lodestar-none.service
+++ b/infra/cl-configs/lodestar-none.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Lodestar (subscribe none)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStart=docker run --network host --mount "type=bind,src=/storage/lodestar/none,dst=/mnt/lodestar" \
+	chainsafe/lodestar:v1.13.0-rc.0 \
+	beacon \
+	--dataDir "/mnt/lodestar" \
+	--execution.urls "https://api.blockprint.sigp.io/eleel" \
+	--jwt-secret "/mnt/lodestar/jwt.hex" \
+	--jwtId "bpw3" \
+	--checkpointSyncUrl "https://mainnet.checkpoint.sigp.io" \
+	--suggestedFeeRecipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--port 9010 \
+	--rest.port 7010

--- a/infra/cl-configs/nimbus-all.service
+++ b/infra/cl-configs/nimbus-all.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Nimbus Beacon Node
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=sigp
+Group=sigp
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/sigp
+ExecStart=docker run --network host --mount "type=bind,src=/storage/nimbus/all,dst=/mnt/nimbus" \
+	statusim/nimbus-eth2:amd64-latest \
+	--data-dir=/mnt/nimbus \
+	--tcp-port=9001 \
+	--udp-port=9001 \
+	--rest-port=7000 \
+	--rest=true \
+	--web3-url="https://api.blockprint.sigp.io/eleel" \
+	--jwt-secret="/mnt/nimbus/jwt.hex" \
+	--suggested-fee-recipient=0xffffffffffffffffffffffffffffffffffffffff \
+	--history=prune \
+	--subscribe-all-subnets=true
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/prysm-all.service
+++ b/infra/cl-configs/prysm-all.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Prysm (all subnets)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=blockprint
+Group=blockprint
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/blockprint
+ExecStart=docker run --network host --mount "type=bind,src=/storage/prysm/all,dst=/mnt/prysm" \
+	gcr.io/prysmaticlabs/prysm/beacon-chain:stable \
+	--accept-terms-of-use \
+	--checkpoint-sync-url="https://mainnet.checkpoint.sigp.io" \
+	--execution-endpoint="https://api.blockprint.sigp.io/eleel" \
+	--jwt-secret="/mnt/prysm/jwt.hex" \
+	--suggested-fee-recipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--p2p-tcp-port=9005 \
+	--p2p-udp-port=9005 \
+	--grpc-gateway-port=7005 \
+	--subscribe-all-subnets \
+	--datadir "/mnt/prysm/data"
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/prysm-none.service
+++ b/infra/cl-configs/prysm-none.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Prysm (subscribe none)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStart=docker run --network host --mount "type=bind,src=/storage/prysm/none,dst=/mnt/prysm" \
+	gcr.io/prysmaticlabs/prysm/beacon-chain:stable \
+	--accept-terms-of-use \
+	--checkpoint-sync-url="https://mainnet.checkpoint.sigp.io" \
+	--execution-endpoint="https://api.blockprint.sigp.io/eleel" \
+	--jwt-secret="/mnt/prysm/jwt.hex" \
+	--suggested-fee-recipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--save-full-execution-payloads \
+	--p2p-tcp-port=9005 \
+	--p2p-udp-port=9005 \
+	--grpc-gateway-port=7005
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/teku-all.service
+++ b/infra/cl-configs/teku-all.service
@@ -1,0 +1,29 @@
+[Install]
+WantedBy=multi-user.target
+[Unit]
+Description=Teku (subscribe all)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=ubuntu
+Group=ubuntu
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/ubuntu
+ExecStart=docker run --network host --mount "type=bind,src=/storage/teku/all,dst=/mnt/teku" \
+	consensys/teku:latest \
+	--data-base-path "/mnt/teku" \
+	--ee-endpoint "http://localhost:8552" \
+	--ee-jwt-secret-file "/mnt/teku/jwt.hex" \
+	--initial-state "https://mainnet.checkpoint.sigp.io/eth/v2/debug/beacon/states/finalized" \
+	--validators-proposer-default-fee-recipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--p2p-port 9000 \
+	--rest-api-enabled true \
+	--rest-api-port 7000 \
+	--log-destination console \
+        --p2p-subscribe-all-subnets-enabled true
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/cl-configs/teku-none.service
+++ b/infra/cl-configs/teku-none.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Teku (subscribe none)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=sigp
+Group=sigp
+Type=simple
+Restart=always
+RestartSec=5
+WorkingDirectory=/home/sigp
+ExecStart=docker run --network host --mount "type=bind,src=/storage/teku/none,dst=/mnt/teku" \
+	consensys/teku:latest \
+	--data-base-path "/mnt/teku" \
+	--ee-endpoint "https://api.blockprint.sigp.io/eleel" \
+	--ee-jwt-secret-file "/mnt/teku/jwt.hex" \
+	--ee-jwt-claim-id "bpw1" \
+	--initial-state "https://mainnet.checkpoint.sigp.io/eth/v2/debug/beacon/states/finalized" \
+	--validators-proposer-default-fee-recipient 0xffffffffffffffffffffffffffffffffffffffff \
+	--p2p-port 9002 \
+	--rest-api-enabled true \
+	--rest-api-port 7002 \
+	--log-destination console
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is not intended to be merged necessarily. It's just a dump of all the flags I was using to run CL clients in v1 of our infrastructure. This can act as a reference for setting up clients in v2 @magick93.

There's a mix of dockerised and non-dockerised nodes here, it's a bit random. We probably just want to draw inspiration from the flags used for each client.

The eleel "controller" roles are a bit random too. We probably want that to be configurable on a per-node basis, i.e. whether we connect to `https://eleel:8551` or `https://eleel:8552/canonical`.