### PR TITLE
Fixing typo in api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,7 @@ These APIs intentionally group data by epoch to avoid identifying individual val
 Get block proposer client affinity for a single epoch.
 
 ```bash
-curl "https://api.blockprint.sigp.io/blocks_per_client/96000
+curl "https://api.blockprint.sigp.io/blocks_per_client/96000"
 ```
 
 ```json


### PR DESCRIPTION
The first `curl` command in `docs/api.md` lacks a character for the command to be copy/pastable.